### PR TITLE
Feat/switch zones

### DIFF
--- a/d2/src/app/components/Picker.jsx
+++ b/d2/src/app/components/Picker.jsx
@@ -7,13 +7,18 @@ import { useZoneStore } from "../store/zoneStore";
 
 const ZoneTypeSelector = () => {
   const { selectedZone, setSelectedZone } = useZoneStore();
+
+  const handlePickerValueChange = (value) => {
+    setSelectedZone(value);
+  };
+
   const options = [
     { value: "1", label: "First Zone" },
     { value: "2", label: "Second Zone" },
     { value: "3", label: "Third Zone" },
   ];
   return (
-    <Select.Root>
+    <Select.Root value={selectedZone} onValueChange={handlePickerValueChange}>
       <SelectTrigger aria-label="zones">
         <Select.Value placeholder="Select a Zone to paint with " />
       </SelectTrigger>

--- a/d2/src/app/components/Picker.jsx
+++ b/d2/src/app/components/Picker.jsx
@@ -20,13 +20,13 @@ const ZoneTypeSelector = () => {
   return (
     <Select.Root value={selectedZone} onValueChange={handlePickerValueChange}>
       <SelectTrigger aria-label="zones">
-        <Select.Value placeholder="Select a Zone to paint with " />
+        <Select.Value placeholder="Select a Zone to paint with" />
       </SelectTrigger>
       <Select.Portal>
         <SelectContent>
           <SelectViewport>
             <Select.Group>
-              <SelectLabel>{selectedZone}</SelectLabel>
+              <SelectLabel>{"Zones"}</SelectLabel>
               {options.map((option) => (
                 <SelectItem key={option.value} value={option.value}>
                   {option.label}

--- a/d2/src/app/constants/layers.ts
+++ b/d2/src/app/constants/layers.ts
@@ -13,20 +13,15 @@ export const DEFAULT_PAINT_STYLE: ExpressionSpecification = [
 ];
 
 export const ZONE_ASSIGNMENT_STYLE: ExpressionSpecification = [
-  // reference the zone store; if the feature is in the zone array, color it based on the color corresponding with zone id
-  "match",
-  ["get", "zone"],
-  1,
-  "#FF0000",
-  2,
-  "#00FF00",
-  3,
-  "#0000FF",
-  4,
-  "#FFFF00",
-  5,
-  "#FF00FF",
-  "#FF00FF",
+  // based on zone feature state, set fill color
+  "case",
+  ["==", ["feature-state", "zone"], 1],
+  "#ff0000",
+  ["==", ["feature-state", "zone"], 2],
+  "#00ff00",
+  ["==", ["feature-state", "zone"], 3],
+  "#0000ff",
+  "#cecece",
 ];
 
 export const BLOCKS_LAYER: LayerSpecification = {
@@ -59,7 +54,7 @@ export const BLOCKS_HOVER_LAYER: LayerSpecification = {
       0.2,
     ],
 
-    "fill-color": "#cecece",
+    "fill-color": ZONE_ASSIGNMENT_STYLE, //"#ff00ff",
   },
 };
 

--- a/d2/src/app/constants/types.ts
+++ b/d2/src/app/constants/types.ts
@@ -5,30 +5,3 @@ export type GEOID = string;
 
 // create a dict of zone: [geoid]
 export type ZoneDict = Record<Zone, GEOID[]>;
-
-export const COLORS: string[] = [
-  "#FF0000",
-  "#00FF00",
-  "#0000FF",
-  "#FFFF00",
-  "#FF00FF",
-  "#00FFFF",
-  "#FFA500",
-  "#800080",
-  "#008000",
-  "#000080",
-  "#800000",
-  "#808000",
-  "#008080",
-  "#808080",
-  "#C0C0C0",
-  "#FFD700",
-  "#A52A2A",
-  "#800000",
-  "#FF4500",
-  "#DA70D6",
-  "#FF8C00",
-  "#FF69B4",
-  "#FF1493",
-  "#FF6347",
-];

--- a/d2/src/app/store/zoneStore.ts
+++ b/d2/src/app/store/zoneStore.ts
@@ -19,15 +19,19 @@ export const useZoneStore = create<ZoneStore>((set) => ({
   // setZoneAssignments should reference existing dict,
   // and accept a zone id and a list of geoids to add to the list.
   // if the geoids exist in other key lists, they must be removed from those lists.
-  setZoneAssignments: (
-    // zoneAssignments: ZoneDict,
-    zone: Zone,
-    geoids: Array<GEOID>
-  ) =>
+  setZoneAssignments: (zone: Zone, geoids: Array<GEOID>) =>
     set((state) => ({
       zoneAssignments: {
+        // check if geoid is in other zones; if so, remove
+        ...Object.keys(state.zoneAssignments).reduce((acc, key) => {
+          acc[key] = state.zoneAssignments[key].filter(
+            (geoid) => !geoids.includes(geoid)
+          );
+          return acc;
+        }, {}),
+
         ...state.zoneAssignments,
-        [zone]: [...geoids], // Update assignments for specific zone
+        [zone]: [...geoids],
       },
     })),
 }));

--- a/d2/src/app/utils/events/handlers.ts
+++ b/d2/src/app/utils/events/handlers.ts
@@ -20,7 +20,6 @@ export const HighlightFeature = (
   const geoids: Set<string> = new Set(
     features?.map((feature) => feature.properties?.GEOID20)
   );
-  // zoneStoreRef.setZoneAssignments(zoneStoreRef.selectedZone, geoids);
   if (features?.length) {
     zoneStoreRef.current?.setZoneAssignments(
       zoneStoreRef.current?.selectedZone,

--- a/d2/src/app/utils/events/handlers.ts
+++ b/d2/src/app/utils/events/handlers.ts
@@ -14,7 +14,7 @@ export const HighlightFeature = (
         id: feature?.id ?? undefined,
         sourceLayer: BLOCK_LAYER_SOURCE_ID,
       },
-      { hover: true }
+      { hover: true, zone: Number(zoneStoreRef.selectedZone) }
     );
   });
   const geoids: Set<string> = new Set(


### PR DESCRIPTION
- actually `setFeatureState` with zones instead of just setting `hover:true`
- qc store setting behavior- i tested using `geoid:zone` dict but it was way slower than `zone:geoid[]`
- dedup store dicts- if you change a block's assignment, the store will first dedup and then update the appropriate array